### PR TITLE
feat: impossible travels feature

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -106,9 +106,10 @@ type RegistryDefault struct {
 
 	schemaHandler *schema.Handler
 
-	sessionHandler   *session.Handler
-	sessionManager   session.Manager
-	sessionTokenizer *session.Tokenizer
+	sessionHandler         *session.Handler
+	sessionManager         session.Manager
+	sessionTokenizer       *session.Tokenizer
+	sessionTravelValidator session.Validator
 
 	passwordHasher    hash.Hasher
 	passwordValidator password.Validator
@@ -892,4 +893,13 @@ func (m *RegistryDefault) SessionTokenizer() *session.Tokenizer {
 		m.sessionTokenizer = session.NewTokenizer(m)
 	}
 	return m.sessionTokenizer
+}
+
+func (m *RegistryDefault) SessionTravelValidator() session.Validator {
+	if m.sessionTravelValidator == nil {
+		m.sessionTravelValidator = session.NewTravelValidator(
+			session.WithMaxAllowedSpeed(20.0),
+		)
+	}
+	return m.sessionTravelValidator
 }

--- a/go.mod
+++ b/go.mod
@@ -104,13 +104,20 @@ require (
 )
 
 require (
+	github.com/kellydunn/golang-geo v0.7.0
+	github.com/wI2L/jsondiff v0.6.0
+)
+
+require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/cortesi/moddwatch v0.1.0 // indirect
 	github.com/cortesi/termlog v0.0.0-20210222042314-a1eec763abec // indirect
+	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
+	github.com/kylelemons/go-gypsy v1.0.0 // indirect
 	github.com/rjeczalik/notify v0.9.3 // indirect
-	github.com/wI2L/jsondiff v0.6.0 // indirect
+	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	mvdan.cc/sh/v3 v3.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
+github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -532,6 +534,8 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kellydunn/golang-geo v0.7.0 h1:A5j0/BvNgGwY6Yb6inXQxzYwlPHc6WVZR+MrarZYNNg=
+github.com/kellydunn/golang-geo v0.7.0/go.mod h1:YYlQPJ+DPEzrHx8kT3oPHC/NjyvCCXE+IuKGKdrjrcU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
@@ -562,6 +566,8 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/go-gypsy v1.0.0 h1:7/wQ7A3UL1bnqRMnZ6T8cwCOArfZCxFmb1iTxaOOo1s=
+github.com/kylelemons/go-gypsy v1.0.0/go.mod h1:chkXM0zjdpXOiqkCW1XcCHDfjfk14PH2KKkQWxfJUcU=
 github.com/laher/mergefs v0.1.2-0.20230223191438-d16611b2f4e7 h1:PDeBswTUsSIT4QSrzLvlqKlGrANYa7TrXUwdBN9myU8=
 github.com/laher/mergefs v0.1.2-0.20230223191438-d16611b2f4e7/go.mod h1:FSY1hYy94on4Tz60waRMGdO1awwS23BacqJlqf9lJ9Q=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
@@ -894,6 +900,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
+github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmb3/spotify/v2 v2.4.2 h1:j3yNN5lKVEMZQItJF4MHCSZbfNWmXO+KaC+3RFaLlLc=
 github.com/zmb3/spotify/v2 v2.4.2/go.mod h1:XOV7BrThayFYB9AAfB+L0Q0wyxBuLCARk4fI/ZXCBW8=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.cockroach.down.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.cockroach.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+    DROP COLUMN "contains_impossible_travel";

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.cockroach.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+    ADD COLUMN "contains_impossible_travel" boolean DEFAULT 'false';

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.mysql.down.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.mysql.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` DROP COLUMN `contains_impossible_travel`;

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.mysql.up.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.mysql.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  `sessions` ADD COLUMN `contains_impossible_travel` boolean DEFAULT false;

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.postgres.down.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.postgres.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+  DROP COLUMN "contains_impossible_travel";

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.postgres.up.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.postgres.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+  ADD COLUMN "contains_impossible_travel" boolean DEFAULT 'false';

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.sqlite3.down.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.sqlite3.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+    DROP COLUMN "contains_impossible_travel";

--- a/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/202408311620000000000_sessions_add_column_contains_impossible_travel.sqlite3.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sessions"
+    ADD COLUMN "contains_impossible_travel" NUMERIC DEFAULT 'false';

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.cockroach.down.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.cockroach.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+    DROP COLUMN "coordinates";

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.cockroach.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+    ADD COLUMN "coordinates" json;

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.mysql.down.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.mysql.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  DROP COLUMN "coordinates";

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.mysql.up.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.mysql.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  ADD COLUMN "coordinates" json;

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.postgres.down.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.postgres.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  DROP COLUMN "coordinates";

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.postgres.up.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.postgres.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  ADD COLUMN "coordinates" jsonb;

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.sqlite3.down.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.sqlite3.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  DROP COLUMN "coordinates";

--- a/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/202409011620000000000_session_devices_add_column_coordinates.sqlite3.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "session_devices"
+  ADD COLUMN "coordinates" json;

--- a/session/helper.go
+++ b/session/helper.go
@@ -4,7 +4,9 @@
 package session
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -16,4 +18,55 @@ func bearerTokenFromRequest(r *http.Request) (string, bool) {
 	}
 
 	return "", false
+}
+
+const (
+	CloudFlareLatitudeHeader = "Cf-Iplatitude"
+	CloudFlareLongitude      = "Cf-Iplongitude"
+)
+
+type coordinates struct {
+	long float64
+	lat  float64
+}
+
+// getCoordinatesFromRequest fetches
+// a longitude (from a header cf-iplongitude) and a latitude (from a header cf-iplatitude).
+// to follow the convention, it's written with capital letters.
+// source: https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#add-visitor-location-headers
+func getCoordinatesFromRequest(r *http.Request) (coordinates, error) {
+	long, err := strconv.ParseFloat(r.Header.Get(CloudFlareLongitude), 10)
+	if err != nil {
+		return coordinates{}, fmt.Errorf("parsing %q header: %v", CloudFlareLongitude, err)
+	}
+
+	lat, err := strconv.ParseFloat(r.Header.Get(CloudFlareLatitudeHeader), 10)
+	if err != nil {
+		return coordinates{}, fmt.Errorf("parsing %q header: %v", CloudFlareLatitudeHeader, err)
+	}
+
+	return coordinates{
+		long: long,
+		lat:  lat,
+	}, nil
+}
+
+func mapDeviceInfoToCoordinates(devices []Device) []CoordinatesWithLoginTime {
+	out := make([]CoordinatesWithLoginTime, 0, len(devices))
+
+	for _, device := range devices {
+		// After realising the feature, we might have situations, that not all sessions will have coordinates.
+		// To prevent a "bad user experience", we would like to skip "old" saved info about sessions.
+		if device.Coordinates.Longitude == 0 && device.Coordinates.Latitude == 0 {
+			continue
+		}
+
+		out = append(out, CoordinatesWithLoginTime{
+			Longitude: device.Coordinates.Longitude,
+			Latitude:  device.Coordinates.Latitude,
+			LoginTime: device.CreatedAt,
+		})
+	}
+
+	return out
 }

--- a/session/helper_test.go
+++ b/session/helper_test.go
@@ -53,3 +53,60 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		})
 	}
 }
+
+// I would call it Test_getCoordinatesFromRequest, but it's needed to follow the code style
+func TestGetCoordinatesFromRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		h           http.Header
+		want        coordinates
+		errExpected bool
+	}{
+		{
+			name:        "happy path",
+			h:           http.Header{CloudFlareLongitude: {"55.751244"}, CloudFlareLatitudeHeader: {"37.618423"}},
+			want:        coordinates{long: 55.751244, lat: 37.618423},
+			errExpected: false,
+		},
+		{
+			name:        "should have the error: no cf-iplongitude and no cf-iplatitude",
+			h:           http.Header{},
+			want:        coordinates{long: 0, lat: 0},
+			errExpected: true,
+		},
+		{
+			name:        "should have the error: no cf-iplongitude",
+			h:           http.Header{CloudFlareLatitudeHeader: {"37.618423"}},
+			want:        coordinates{long: 0, lat: 0},
+			errExpected: true,
+		},
+		{
+			name:        "should have the error: no cf-iplatitude",
+			h:           http.Header{CloudFlareLongitude: {"55.751244"}},
+			want:        coordinates{long: 0, lat: 0},
+			errExpected: true,
+		},
+		{
+			name:        "should have the error: empty value for cf-iplongitude",
+			h:           http.Header{CloudFlareLongitude: {""}, CloudFlareLatitudeHeader: {"37.618423"}},
+			want:        coordinates{long: 0, lat: 0},
+			errExpected: true,
+		},
+		{
+			name:        "should have the error: empty value for cf-iplatitude",
+			h:           http.Header{CloudFlareLongitude: {"55.751244"}, CloudFlareLatitudeHeader: {""}},
+			want:        coordinates{long: 0, lat: 0},
+			errExpected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := getCoordinatesFromRequest(&http.Request{Header: tc.h})
+			assert.Equal(t, tc.want, result)
+			if tc.errExpected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/session/manager.go
+++ b/session/manager.go
@@ -115,6 +115,24 @@ func NewErrAALNotSatisfied(redirectTo string) *ErrAALNotSatisfied {
 	}
 }
 
+// ErrImpossibleTravel is returned when impossible travel occurred among session logins..
+type ErrImpossibleTravel struct {
+	*herodot.DefaultError `json:"error"`
+}
+
+// NewErrImpossibleTravel creates a new ErrImpossibleTravel
+func NewErrImpossibleTravel() *ErrImpossibleTravel {
+	return &ErrImpossibleTravel{
+		DefaultError: herodot.ErrUnauthorized.WithID(text.ErrImpossibleTravelSession).
+			WithError("request is made from impossible to reach location in a given time").
+			WithReason("Sessions logins are too far between each other.."),
+	}
+}
+
+func (e *ErrImpossibleTravel) EnhanceJSONError() interface{} {
+	return e
+}
+
 // Manager handles identity sessions.
 type Manager interface {
 	// UpsertAndIssueCookie stores a session in the database and issues a cookie by calling IssueCookie.
@@ -147,6 +165,8 @@ type Manager interface {
 	// that the user is able to authenticate with it. This means that if a user has a second factor, the user is always
 	// asked to authenticate with it if `highest_available` is set and the session's AAL is `aal1`.
 	DoesSessionSatisfy(r *http.Request, sess *Session, matcher string, opts ...ManagerOptions) error
+
+	DoesSessionSatisfyTravelRestrictions(r *http.Request, sess *Session) error
 
 	// SessionAddAuthenticationMethods adds one or more authentication method to the session.
 	SessionAddAuthenticationMethods(ctx context.Context, sid uuid.UUID, methods ...AuthenticationMethod) error

--- a/session/session.go
+++ b/session/session.go
@@ -292,6 +292,9 @@ func (s *Session) SetSessionDeviceInformation(r *http.Request) {
 			Latitude:  coords.lat,
 			Longitude: coords.long,
 		}
+	} else {
+		// TODO: we might want to correctly log it or have some metrics (with alerts) to detect "the issue"
+		//	with CloudFlare headers in advance.
 	}
 
 	s.Devices = append(s.Devices, device)

--- a/session/session.go
+++ b/session/session.go
@@ -58,6 +58,9 @@ type Device struct {
 	// Geo Location corresponding to the IP Address
 	Location *string `json:"location" faker:"ptr_geo_location" db:"location"`
 
+	// Coordinates coordinates to the IP Address.
+	Coordinates *Coordinates `json:"coordinates" faker:"ptr_coordinates" db:"coordinates"`
+
 	// Time of capture
 	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`
 
@@ -69,6 +72,11 @@ type Device struct {
 
 func (m Device) TableName(ctx context.Context) string {
 	return "session_devices"
+}
+
+type Coordinates struct {
+	Latitude  float64
+	Longitude float64
 }
 
 // A Session
@@ -130,6 +138,9 @@ type Session struct {
 
 	// Devices has history of all endpoints where the session was used
 	Devices []Device `json:"devices" faker:"-" has_many:"session_devices" fk_id:"session_id"`
+
+	// ContainsImpossibleTravel specifies if a session contains "impossible travel" among its logins.
+	ContainsImpossibleTravel bool `json:"contains_impossible_travel" faker:"contains_impossible_travel" db:"contains_impossible_travel"`
 
 	// IdentityID is a helper struct field for gobuffalo.pop.
 	IdentityID uuid.UUID `json:"-" faker:"-" db:"identity_id"`
@@ -275,6 +286,13 @@ func (s *Session) SetSessionDeviceInformation(r *http.Request) {
 		clientGeoLocation = append(clientGeoLocation, r.Header.Get("Cf-Ipcountry"))
 	}
 	device.Location = pointerx.Ptr(strings.Join(clientGeoLocation, ", "))
+
+	if coords, err := getCoordinatesFromRequest(r); err == nil {
+		device.Coordinates = &Coordinates{
+			Latitude:  coords.lat,
+			Longitude: coords.long,
+		}
+	}
 
 	s.Devices = append(s.Devices, device)
 }

--- a/session/travel_validator.go
+++ b/session/travel_validator.go
@@ -42,6 +42,14 @@ func NewTravelValidator(opts ...ValidatorOptions) *travelValidator {
 	}
 }
 
+// IsValid validates incoming logins (coords with login time) on "impossible travels".
+// Every login is compared to each other to detect "unusual travels" which are not possible
+// to achieve for a given speed `maxAllowedTravelSpeed` (it's configured).
+// If "impossible travel" is detected, the function returns "false", otherwise "true".
+//
+// NOTE: I might assume it can be simplified:
+//	we could compare everything in one iteration, but it's just an assumption, so that's why I
+//	leave it as it is.
 func (tv *travelValidator) IsValid(logins []CoordinatesWithLoginTime) bool {
 	sort.Slice(logins, func(i, j int) bool {
 		return logins[i].LoginTime.After(logins[j].LoginTime)

--- a/session/travel_validator.go
+++ b/session/travel_validator.go
@@ -1,0 +1,93 @@
+package session
+
+import (
+	"sort"
+	"time"
+
+	geo "github.com/kellydunn/golang-geo"
+)
+
+type TravelValidator interface {
+	SessionTravelValidator() Validator
+}
+
+type Validator interface {
+	IsValid(logins []CoordinatesWithLoginTime) bool
+}
+
+const defaultAllowedSpeed = 10
+
+type CoordinatesWithLoginTime struct {
+	Longitude float64
+	Latitude  float64
+
+	LoginTime time.Time
+}
+
+type travelValidator struct {
+	maxAllowedTravelSpeed float64 // km/h
+}
+
+func NewTravelValidator(opts ...ValidatorOptions) *travelValidator {
+	cfg := &validatorOptions{
+		maxAllowedTravelSpeed: defaultAllowedSpeed,
+	}
+
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	return &travelValidator{
+		maxAllowedTravelSpeed: cfg.maxAllowedTravelSpeed,
+	}
+}
+
+func (tv *travelValidator) IsValid(logins []CoordinatesWithLoginTime) bool {
+	sort.Slice(logins, func(i, j int) bool {
+		return logins[i].LoginTime.After(logins[j].LoginTime)
+	})
+
+	for currentInd, currentLogin := range logins {
+		for targetInd := currentInd + 1; targetInd <= len(logins)-1; targetInd++ {
+			targetLogin := logins[targetInd]
+
+			currentGeoPoint := geo.NewPoint(currentLogin.Latitude, currentLogin.Longitude)
+			targetGeoPoint := geo.NewPoint(targetLogin.Latitude, targetLogin.Longitude)
+
+			distanceKM := currentGeoPoint.GreatCircleDistance(targetGeoPoint)
+
+			timeDiff := currentLogin.LoginTime.Sub(targetLogin.LoginTime).Seconds()
+
+			if timeDiff == 0 {
+				if distanceKM == 0 {
+					continue
+				} else {
+					return false
+				}
+			}
+
+			if distanceKM/(timeDiff/60/60) > tv.maxAllowedTravelSpeed {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+type ValidatorOptions func(*validatorOptions)
+
+type validatorOptions struct {
+	maxAllowedTravelSpeed float64 // km/h
+}
+
+// WithMaxAllowedSpeed passes along the max allowed speed in km/h for the distance sessions.
+func WithMaxAllowedSpeed(maxAllowedTravelSpeed float64) ValidatorOptions {
+	return func(opts *validatorOptions) {
+		if maxAllowedTravelSpeed == 0 {
+			return
+		}
+
+		opts.maxAllowedTravelSpeed = maxAllowedTravelSpeed
+	}
+}

--- a/session/travel_validator_test.go
+++ b/session/travel_validator_test.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_travelValidator_IsValid(t *testing.T) {
+	type fields struct {
+		maxAllowedTravelSpeed float64
+	}
+
+	type args struct {
+		logins []CoordinatesWithLoginTime
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "it returns TRUE for one login only",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Now().UTC(),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "it returns TRUE for logins ~10km apart with a max speed 10 km/h and 2h time difference",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.45912124487777,
+						Latitude:  55.77524387014726,
+						LoginTime: time.Date(2024, time.March, 1, 16, 00, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "it returns TRUE for logins ~10km apart with a max speed 10 km/h and 2h time dif and reversed orderd logins",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 16, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.45912124487777,
+						Latitude:  55.77524387014726,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "it returns TRUE for logins 0km apart with a max speed 10 km/h and 0 min time difference",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "it returns FALSE for logins 10km apart with a max speed 10 km/h and 0 min time difference",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.45912124487777,
+						Latitude:  55.77524387014726,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "it returns FALSE for logins ~10km apart with a max speed 10 km/h and 30 min time difference",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.45912124487777,
+						Latitude:  55.77524387014726,
+						LoginTime: time.Date(2024, time.March, 1, 14, 30, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "it returns FALSE for multiple valid logins and the one which is made from a 1960km apart in less than 2h",
+			fields: fields{
+				maxAllowedTravelSpeed: 10,
+			},
+			args: args{
+				logins: []CoordinatesWithLoginTime{
+					{
+						Longitude: 37.618423,
+						Latitude:  55.751244,
+						LoginTime: time.Date(2024, time.March, 1, 14, 00, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.616376252227084,
+						Latitude:  55.756094714362014,
+						LoginTime: time.Date(2024, time.March, 1, 14, 10, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.605474880975905,
+						Latitude:  55.764490414061235,
+						LoginTime: time.Date(2024, time.March, 1, 14, 20, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.59620641906158,
+						Latitude:  55.76984009358484,
+						LoginTime: time.Date(2024, time.March, 1, 14, 30, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 37.584734757147196,
+						Latitude:  55.77641564850109,
+						LoginTime: time.Date(2024, time.March, 1, 14, 35, 00, 00, time.UTC),
+					},
+					{
+						Longitude: 11.578439526689374,
+						Latitude:  48.13609197557769,
+						LoginTime: time.Date(2024, time.March, 1, 15, 22, 00, 00, time.UTC),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("case=%s", tt.name), func(t *testing.T) {
+			tv := NewTravelValidator(
+				WithMaxAllowedSpeed(tt.fields.maxAllowedTravelSpeed),
+			)
+
+			assert.Equalf(t, tt.want, tv.IsValid(tt.args.logins), "IsValid(%v)", tt.args.logins)
+		})
+	}
+}

--- a/text/message_error.go
+++ b/text/message_error.go
@@ -18,6 +18,7 @@ const (
 	ErrIDSessionRequiredForHigherAAL = "session_aal1_required"
 	ErrIDHigherAALRequired           = "session_aal2_required"
 	ErrNoActiveSession               = "session_inactive"
+	ErrImpossibleTravelSession       = "session_contains_impossible_travel"
 	ErrIDRedirectURLNotAllowed       = "self_service_flow_return_to_forbidden"
 	ErrIDInitiatedBySomeoneElse      = "security_identity_mismatch"
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
# Purpose 

This PR introduces the "impossible travel" detection". This feature prevents malicious people, who are located "far away' from the "regular locations", make use of "users' accounts" .

## Details of implementation

The functionality is based on following resources:
- geo library for calculation between 2 coordinates: https://github.com/kellydunn/golang-geo
- Cloudflare headers such as `cf-iplongitude` and `cf-iplatitude`: https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#add-visitor-location-headers
NOTE: in the code these headers are used with capital letters.

This PR includes:
- a functionality of calculating distance between 2 coordinates based on longitude and latitude values. (`travelValidator.IsValid`) with unit tests 
- a new field `Coordinates` for the `Device` object to store info about coordinates
- a new field `ContainsImpossibleTravel` for the `Session ` object to mark sessions which contains "impossible travels"
- 2 helper functions to handle new functionality with coordinates. Covered by unit tests.
- migration files for column creations for `Device` and `Session` models for possible databases were implemented (based on the existing list of dbs inside codebase and migration files).
- `session.ManagerHTTP` were extended with a new function `DoesSessionSatisfyTravelRestrictions` which prepare "logins with coord and time" to validate and returns the new introduced err `ErrImpossibleTravel` if session is not valid.
- the función `DoesSessionSatisfyTravelRestrictions ` is used as the last step  of the `FetchFromRequest ` . If the session is not valid due to "impossible" travel, we mark the session with this info.

## Crucial Missed Parts

- fixed all failed tests due to introduced feature
- to write tests for `FetchFromRequest` 
- to write tests for `DoesSessionSatisfyTravelRestrictions` 
- to write e2e and integration tests to cover "impossible travel" feature
- I might assume, that the feature is not switched on with a current implementation. It's needed to use `SessionTravelValidator` somewhere in the codebase.
- make configurable `MaxAllowedSpeed` and other potential thresholds.


## Futhure improvements

- to add more configurations on speed. Depending on distances between coordinates we might want to have different max allowed speed. For example, for the distance up to 10km - 20km/h is max (a bike), for the distance up to 500km - 120km/h is max (a car), for the distance from 500km - 900km/h is max (a plane),
- Potentially, it's needed during the release update the current "active" sessions with coordinates. It can be achieved by detecting coordinates by `Location` field of `Device` model. On the running state of application, the worker will check on "active" sessions, fetches coordinates by `Location` field from the third party API and update the existing objects. The advantage of it is: we will be having more accurate information to detect "impossible" travels. The distadvavage of it is: it might be a "heavy" operation to update all rows in DBs.
- Potentially, it's possible to simplify a function for `travelValidator.IsValid` - the thoughts are written above the function in the code
- Introduce metrics: `count impossible travel events` 

## Comments

The biggest "time consumed work" was related to finding the appropriate place to implement the feature. 
That's why I feel I didn't manage to provide a lot of tests for the functionality.
However, the task was quite interesting. Thx for the opportunity. 


